### PR TITLE
Remove accountability headline, add index descriptions

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -161,7 +161,6 @@
           %>
           </div>
           <div class="section categories">
-              <h3>Accountability ratings</h3>
               <div class="legend-row row">
                 <div class="col-sm-6">
                   <div class="legend-text col-xs-2"><strong>Legend:</strong></div>
@@ -176,7 +175,11 @@
               </div>
               <% _.each(["Student Achievement (Index 1)","Student Progress (Index 2)","Closing Performance Gaps (Index 3)","Postsecondary Readiness (Index 4)"],
                     function(title, i) { %>
-              <p class="leadish italic"><%= title %></p>
+              <h3><%= title %></h3>
+              <p class="leadish italic"><%= ["Student performance across all subjects.",
+                "Student performance improvement.",
+                "Academic achievement of economically disadvantaged students and the two lowest-performing racial student groups.",
+                "Measure of a school’s ability to prepare its students for the next level of education, or the workforce."][i] %></p>
               <div class="index-chart">
 
                   <div class="row">


### PR DESCRIPTION
Adds the descriptions listed in the header chatter to the charts in order to better explain the numbers

![screen shot 2016-08-15 at 3 30 37 pm](https://cloud.githubusercontent.com/assets/1087467/17678576/4fedded2-62fd-11e6-85d2-8208b04fbda1.png)
